### PR TITLE
Changed Silk Caterpillar spawn mechanics

### DIFF
--- a/scripts/zones/Rolanberry_Fields/Zone.lua
+++ b/scripts/zones/Rolanberry_Fields/Zone.lua
@@ -67,9 +67,6 @@ function onInitialize(zone)
     -- Simurgh
     SetRespawnTime(17228242, 900, 10800);
 
-    -- Spawns Silk Caterpillar (temporary until someone implements a way to make it spawn properly)
-    SpawnMob(17227782,300,660);
-
 end;
 
 -----------------------------------
@@ -117,13 +114,15 @@ end;
 
 function onGameHour()
 
-    local VanadielHour = VanadielHour();
-    local SilkCaterpillar = 17227782;
-        
-    if (VanadielHour % 1 == 0 and GetMobAction( SilkCaterpillar ) == 16) then 
-        DespawnMob( SilkCaterpillar );
-    end
-    
+    local vanadielHour = VanadielHour();
+    local silkCaterpillarId = 17227782;
+    --Silk Caterpillar should spawn every 6 hours from 03:00
+    --this is approximately when the Jeuno-Bastok airship is flying overhead towards Jeuno.
+    if (vanadielHour % 6 == 3 and GetMobAction(silkCaterpillarId) == ACTION_NONE) then
+    -- Despawn set to 210 seconds (3.5 minutes, approx when the Jeuno-Bastok airship is flying back over to Bastok).
+    SpawnMob(silkCaterpillarId, 210);
+  end
+  
 end;
 
 -----------------------------------


### PR DESCRIPTION
Removed spawning of Silk Caterpillar from onInitialize and removed the despawn logic from onGameHour as I'm not entirely sure what it was trying to achieve.

Added spawning logic to onGameHour so we check every Vanadiel Hour if the Silk Caterpillar should spawn, will only actually spawn at 03:00, 09:00, 15:00 and 21:00 as these are the approximate times the Jeuno-Bastok airship will be flying into Jeuno.

Despawns 210 seconds later if left unclaimed (approximately when the Jeuno-Bastok airship flies out of Jeuno).

All Airship timings were taken from ffxiclopedia.

Tested spawning and despawning and that it definitely drops that damn silkworm egg!

Only thing is I'm not sure about explicitly stating the Caterpillar's ID, is this likely to change?
